### PR TITLE
[fix/ranking] : 기존유저를 저장하는 위치를 변경

### DIFF
--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/MainActivity.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/MainActivity.kt
@@ -32,32 +32,32 @@ class MainActivity : AppCompatActivity() {
         val navController = navHostFragment.navController
         NavigationUI.setupWithNavController(binding.bottomNavigationView, navController)
 
-        binding.bottomNavigationView.setOnNavigationItemSelectedListener {
+        binding.bottomNavigationView.setOnItemSelectedListener {
             when (it.itemId) {
                 R.id.fragment_home -> {
                     if (MyongsikApplication.prefs.getUserCampus() == "Y") {
                         navController.navigate(R.id.fragment_select_home)
-                        return@setOnNavigationItemSelectedListener true
+                        return@setOnItemSelectedListener true
                     } else{
                         navController.navigate(R.id.fragment_home)
                     }
                 }
                 R.id.fragment_search -> {
                         navController.navigate(R.id.fragment_search)
-                        return@setOnNavigationItemSelectedListener true
+                        return@setOnItemSelectedListener true
                 }
                 R.id.fragment_love -> {
                         navController.navigate(R.id.fragment_love)
-                        return@setOnNavigationItemSelectedListener true
+                        return@setOnItemSelectedListener true
                 }
                 // 다른 항목에 대한 처리 추가 가능
                 else -> {
                     // 처리할 로직이 없을 경우에도 true를 반환하여 이벤트를 소비하도록 구현
-                    return@setOnNavigationItemSelectedListener true
+                    return@setOnItemSelectedListener true
                 }
             }
             // 선택된 메뉴 항목에 대한 처리가 끝나고 true를 반환하여 이벤트를 소비하도록 구현
-            return@setOnNavigationItemSelectedListener true
+            return@setOnItemSelectedListener true
         }
 
         navController.addOnDestinationChangedListener { _, destination, _ ->

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
@@ -28,6 +28,7 @@ import com.myongsik.myongsikandroid.ui.adapter.state.SearchFoodLoadStateAdapter
 import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
 import com.myongsik.myongsikandroid.ui.viewmodel.SearchViewModel
 import com.myongsik.myongsikandroid.util.Constant.SEARCH_FOODS_TIME_DELAY
+import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -73,6 +74,7 @@ class SearchFragment : Fragment(), OnSearchViewHolderClick, OnScrapViewHolderCli
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        MyongsikApplication.prefs.setString("newUser", "notNew")
 
         setUpRecyclerView()
         setUpRankRestaurantRV()


### PR DESCRIPTION
## 변경된점
- MainActivity : Deprecated 된 부분 수정
- SplashFragment : try catch 로 ConnectException 처리
- SearchFragment : 스플래시화면에서 기기 등록을 한 후 preference 값에 기존유저를 뜻하는 값을 저장해주었는데, 혹시나 크래시가 발생하거나 네트워크 통신을 못했는데, 기존유저로 저장이 되는 상황을 피하기 위해 기기등록하고 정상적으로 Search로 접속했을 때 preference 값을 바꾸어 주었음