### PR TITLE
[fix/dialog backbtn] : 다이얼로그 백버튼 로직 수정

### DIFF
--- a/app/src/main/java/com/myongsik/myongsikandroid/data/model/food/RankRestaurantResponse.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/data/model/food/RankRestaurantResponse.kt
@@ -17,5 +17,7 @@ data class GetRankRestaurant(
     val urlAddress : String,
     val distance : String,
     val scrapCount : Int?,
-    val contact : String
+    val contact : String,
+    val x : String?,
+    val y : String?
 )

--- a/app/src/main/java/com/myongsik/myongsikandroid/data/model/kakao/SearchResponse.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/data/model/kakao/SearchResponse.kt
@@ -16,7 +16,7 @@ fun SearchResponse.toRankRestaurant(): ArrayList<GetRankRestaurant> {
         list.add(
             GetRankRestaurant(
                 storeId = it.id.toInt(),
-                code = it.category_group_code,
+                code = it.id,
                 name = it.place_name,
                 category = it.category_group_name,
                 address = it.road_address_name,
@@ -24,6 +24,8 @@ fun SearchResponse.toRankRestaurant(): ArrayList<GetRankRestaurant> {
                 distance = it.distance,
                 scrapCount = null,
                 contact = it.phone,
+                x = it.x,
+                y = it.y
             )
         )
     }

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/adapter/food/RankRestaurantViewHolder.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/adapter/food/RankRestaurantViewHolder.kt
@@ -70,10 +70,6 @@ class RankRestaurantViewHolder(
             itemFoodDetailCl.setOnClickListener {
                 clickCallback.clickRankDirectButton(getRankRestaurant)
             }
-
-            itemFoodDetailCl.setOnClickListener {
-                clickCallback.clickRankDirectButton(getRankRestaurant)
-            }
         }
     }
 

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -37,10 +36,8 @@ import com.myongsik.myongsikandroid.util.Constant.SEARCH_FOODS_TIME_DELAY
 import com.myongsik.myongsikandroid.util.DataStoreKey
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.random.Random
 
 @AndroidEntryPoint class SearchFragment : Fragment(), OnSearchViewHolderClick, OnScrapViewHolderClick {
@@ -287,23 +284,22 @@ import kotlin.random.Random
     }
 
     override fun onHashtagGoodFoodClick() {
-        Log.d("gg", "gg")
-        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment("맛집")
+        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment(getString(R.string.tag_good_restaurant))
         findNavController().navigate(action)
     }
 
     override fun onHashtagGoodCafeClick() {
-        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment("카페")
+        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment(getString(R.string.tag_good_cafe))
         findNavController().navigate(action)
     }
 
     override fun onHashtagGoodDrinkClick() {
-        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment("술집")
+        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment(getString(R.string.tag_good_drink))
         findNavController().navigate(action)
     }
 
     override fun onHashtagGoodBreadClick() {
-        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment("빵집")
+        val action = SearchFragmentDirections.actionFragmentSearchToTagFragment(getString(R.string.tag_good_bread))
         findNavController().navigate(action)
     }
 

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
@@ -276,8 +276,8 @@ import kotlin.random.Random
             place_name = getRankRestaurant.name,
             place_url = getRankRestaurant.urlAddress,
             road_address_name = getRankRestaurant.address,
-            x = " ",
-            y = " "
+            x = getRankRestaurant.x ?: " ",
+            y = getRankRestaurant.y ?: " "
         )
         val action = SearchFragmentDirections.actionFragmentSearchToRestaurantFragment(restaurant)
         findNavController().navigate(action)

--- a/app/src/main/java/com/myongsik/myongsikandroid/util/DialogUtils.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/util/DialogUtils.kt
@@ -87,7 +87,7 @@ class DialogUtils(private val context: Context) {
         builder.setView(dialogView)
 
         val alertDialog = builder.create()
-        alertDialog.setCancelable(false)
+        alertDialog.setCancelable(true)
         alertDialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
         dialogView.findViewById<TextView>(R.id.review_confirm_btn).setOnClickListener {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,9 @@
     <string name="please_opinion_write">의견을 작성해주세요!</string>
     <string name="weekend_noti">주말 운영 안내</string>
     <string name="weekend_not_service">주말에는 식당을 운영하지 않습니다.</string>
+
+    <string name="tag_good_restaurant">맛집</string>
+    <string name="tag_good_cafe">카페</string>
+    <string name="tag_good_drink">술집</string>
+    <string name="tag_good_bread">빵집</string>
 </resources>


### PR DESCRIPTION
## 변경사항
- 리뷰 다이얼로그에서 백버튼 클릭시 닫히게, 너무 간단해서 태그 string 분리하였습니다....ㅎ
- 추가로 이 브랜치에서 두 번째 이슈도 진행해볼게용

## 이슈사항
- #86 
- 추천시에서 찜 할 때 데이터베이스 code값에 FD6라는 음식점 코드값이 들어감.
- 하지만 우리 데이터베이스에는 code 값이 store의 고유값임
- 데이터베이스 설계할 때 네이밍이 안맞아서 생긴 이슈같아요.
- 추천시는 오픈 api, 랭킹은 서버 api 이기 때문에 scrapCount, storeId의 값이 다르기 때문에 code값을 id값으로 변경해서 강제로 id값이 들어가게 하였습니다!
- 이슈 사항이 헷갈리실 것 같아 만일 더 문의사항 있으면 슬랙이나 구두로 문의주세요!