### PR TITLE
[fix/separation of concerns] : ViewModel 관심사 분리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:theme="@style/Theme.Myongsik_android"
         android:usesCleartextTraffic="true">
         <activity
-            android:name=".ui.view.food.MainActivity"
+            android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/myongsik/myongsikandroid/BaseViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/BaseViewModel.kt
@@ -1,4 +1,4 @@
-package com.myongsik.myongsikandroid.ui.viewmodel
+package com.myongsik.myongsikandroid
 
 import android.util.Log
 import androidx.lifecycle.LiveData

--- a/app/src/main/java/com/myongsik/myongsikandroid/MainActivity.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.myongsik.myongsikandroid.ui.view.food
+package com.myongsik.myongsikandroid
 
 import android.app.AlarmManager
 import android.app.PendingIntent
@@ -8,7 +8,6 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.NavigationUI
-import com.myongsik.myongsikandroid.R
 import com.myongsik.myongsikandroid.alarm.AlarmBroadCastReceiver
 import com.myongsik.myongsikandroid.databinding.ActivityMainBinding
 import com.myongsik.myongsikandroid.util.MyongsikApplication

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/adapter/food/MyPagerAdapter.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/adapter/food/MyPagerAdapter.kt
@@ -6,7 +6,6 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View.GONE
 import android.view.ViewGroup
@@ -14,7 +13,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.myongsik.myongsikandroid.R
 import com.myongsik.myongsikandroid.databinding.ItemHomeTodayFoodBinding
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.food.HomeViewModel
 import com.myongsik.myongsikandroid.util.Constant.DINNER
 import com.myongsik.myongsikandroid.util.Constant.DINNER_H
 import com.myongsik.myongsikandroid.util.Constant.DINNER_S
@@ -28,7 +27,7 @@ import java.util.*
 
 class MyPagerAdapter(
     private val itemList: List<List<List<String>>>,
-    private val mainViewModel: MainViewModel
+    private val homeViewModel: HomeViewModel
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -263,7 +262,7 @@ class MyPagerAdapter(
                         )
                     ) {
                         defaultChangeB()
-                        mainViewModel.saveLunchEvaluation("B", "")
+                        homeViewModel.saveLunchEvaluation("B", "")
                         return@setOnClickListener
                     }
                 }
@@ -279,7 +278,7 @@ class MyPagerAdapter(
                         // 인캠의 경우
                         LUNCH_B_GOOD = "good"
                         getGoodChangeLunchB()
-                        mainViewModel.saveLunchEvaluation("B", "good")
+                        homeViewModel.saveLunchEvaluation("B", "good")
 
                     },
                     noClickListener = {
@@ -297,7 +296,7 @@ class MyPagerAdapter(
                         )
                     ) {
                         defaultChangeB()
-                        mainViewModel.saveLunchEvaluation("B", "")
+                        homeViewModel.saveLunchEvaluation("B", "")
                         return@setOnClickListener
                     }
                 }
@@ -313,7 +312,7 @@ class MyPagerAdapter(
                         // 인캠의 경우
                         LUNCH_B_GOOD = "hate"
                         getHateChangeLunchB()
-                        mainViewModel.saveLunchEvaluation("B", "hate")
+                        homeViewModel.saveLunchEvaluation("B", "hate")
 
                     },
                     noClickListener = {
@@ -331,7 +330,7 @@ class MyPagerAdapter(
                             )
                         ) {
                             defaultChangeA()
-                            mainViewModel.saveLunchEvaluation("A", "")
+                            homeViewModel.saveLunchEvaluation("A", "")
                             return@setOnClickListener
                         }
                     }
@@ -343,7 +342,7 @@ class MyPagerAdapter(
                                 )
                             ) {
                                 defaultChangeA()
-                                mainViewModel.saveLunchEvaluation("AS", "")
+                                homeViewModel.saveLunchEvaluation("AS", "")
                                 return@setOnClickListener
                             }
                         }
@@ -355,7 +354,7 @@ class MyPagerAdapter(
                                 )
                             ) {
                                 defaultChangeA()
-                                mainViewModel.saveLunchEvaluation("AH", "")
+                                homeViewModel.saveLunchEvaluation("AH", "")
                                 return@setOnClickListener
                             }
                         }
@@ -374,20 +373,20 @@ class MyPagerAdapter(
                         if (itemList[0].size.toString() == "3" || MyongsikApplication.prefs.getUserArea() == "S") {
                             LUNCH_A_GOOD = "good"
                             getGoodChangeLunchA()
-                            mainViewModel.saveLunchEvaluation("A", "good")
+                            homeViewModel.saveLunchEvaluation("A", "good")
                         }
                         // 자캠의 경우
                         else {
                             if (MyongsikApplication.prefs.getUserArea() == "L") {
                                 LUNCH_A_GOOD_S = "good"
                                 getGoodChangeLunchA()
-                                mainViewModel.saveLunchEvaluation("AS", "good")
+                                homeViewModel.saveLunchEvaluation("AS", "good")
 
                             }
                             if (MyongsikApplication.prefs.getUserArea() == "H") {
                                 LUNCH_A_GOOD_H = "good"
                                 getGoodChangeLunchA()
-                                mainViewModel.saveLunchEvaluation("AH", "good")
+                                homeViewModel.saveLunchEvaluation("AH", "good")
 
                             }
                         }
@@ -407,7 +406,7 @@ class MyPagerAdapter(
                         ) {
 
                             defaultChangeA()
-                            mainViewModel.saveLunchEvaluation("A", "")
+                            homeViewModel.saveLunchEvaluation("A", "")
                             return@setOnClickListener
                         }
                     }
@@ -420,7 +419,7 @@ class MyPagerAdapter(
                         ) {
 
                             defaultChangeA()
-                            mainViewModel.saveLunchEvaluation("AS", "")
+                            homeViewModel.saveLunchEvaluation("AS", "")
                             return@setOnClickListener
                         }
                     }
@@ -432,7 +431,7 @@ class MyPagerAdapter(
                             )
                         ) {
                             defaultChangeA()
-                            mainViewModel.saveLunchEvaluation("AH", "")
+                            homeViewModel.saveLunchEvaluation("AH", "")
                             return@setOnClickListener
                         }
                     }
@@ -447,19 +446,19 @@ class MyPagerAdapter(
                         if (itemList[0].size.toString() == "3" || MyongsikApplication.prefs.getUserArea() == "S") {
                             LUNCH_A_GOOD = "hate"
                             getHateChangeLunchA()
-                            mainViewModel.saveLunchEvaluation("A", "hate")
+                            homeViewModel.saveLunchEvaluation("A", "hate")
                         }
                         // 자캠의 경우
                         else {
                             if (MyongsikApplication.prefs.getUserArea() == "L") {
                                 LUNCH_A_GOOD_S = "hate"
                                 getHateChangeLunchA()
-                                mainViewModel.saveLunchEvaluation("AS", "hate")
+                                homeViewModel.saveLunchEvaluation("AS", "hate")
                             }
                             if (MyongsikApplication.prefs.getUserArea() == "H") {
                                 LUNCH_A_GOOD_H = "hate"
                                 getHateChangeLunchA()
-                                mainViewModel.saveLunchEvaluation("AH", "hate")
+                                homeViewModel.saveLunchEvaluation("AH", "hate")
                             }
                         }
                     },
@@ -479,7 +478,7 @@ class MyPagerAdapter(
                         ) {
 
                             defaultChange()
-                            mainViewModel.saveLunchEvaluation("D", "")
+                            homeViewModel.saveLunchEvaluation("D", "")
                             return@setOnClickListener
                         }
                     }
@@ -492,7 +491,7 @@ class MyPagerAdapter(
                         ) {
 
                             defaultChange()
-                            mainViewModel.saveLunchEvaluation("DS", "")
+                            homeViewModel.saveLunchEvaluation("DS", "")
                             return@setOnClickListener
                         }
                     }
@@ -505,7 +504,7 @@ class MyPagerAdapter(
                         ) {
 
                             defaultChange()
-                            mainViewModel.saveLunchEvaluation("DH", "")
+                            homeViewModel.saveLunchEvaluation("DH", "")
                             return@setOnClickListener
                         }
                     }
@@ -523,7 +522,7 @@ class MyPagerAdapter(
                         if (itemList[0].size.toString() == "3" || MyongsikApplication.prefs.getUserArea() == "S") {
                             DINNER = "good"
                             getGoodChangeDinner()
-                            mainViewModel.saveLunchEvaluation("D", "good")
+                            homeViewModel.saveLunchEvaluation("D", "good")
                         }
                         // 자캠의 경우
                         else {
@@ -532,14 +531,14 @@ class MyPagerAdapter(
                                 DINNER_S = "good"
                                 getGoodChangeDinner()
 
-                                mainViewModel.saveLunchEvaluation("DS", "good")
+                                homeViewModel.saveLunchEvaluation("DS", "good")
                             }
                             if (MyongsikApplication.prefs.getUserArea() == "H") {
 
                                 DINNER_H = "good"
                                 getGoodChangeDinner()
 
-                                mainViewModel.saveLunchEvaluation("DH", "good")
+                                homeViewModel.saveLunchEvaluation("DH", "good")
                             }
                         }
                     },
@@ -558,7 +557,7 @@ class MyPagerAdapter(
                             )
                         ) {
                             defaultChange()
-                            mainViewModel.saveLunchEvaluation("D", "")
+                            homeViewModel.saveLunchEvaluation("D", "")
                             return@setOnClickListener
                         }
                     }
@@ -570,7 +569,7 @@ class MyPagerAdapter(
                             )
                         ) {
                             defaultChange()
-                            mainViewModel.saveLunchEvaluation("DS", "")
+                            homeViewModel.saveLunchEvaluation("DS", "")
                             return@setOnClickListener
                         }
                     }
@@ -583,7 +582,7 @@ class MyPagerAdapter(
                         ) {
 
                             defaultChange()
-                            mainViewModel.saveLunchEvaluation("DH", "")
+                            homeViewModel.saveLunchEvaluation("DH", "")
                             return@setOnClickListener
 
                         }
@@ -601,21 +600,21 @@ class MyPagerAdapter(
                             DINNER = "hate"
                             getHateChangeDinner()
 
-                            mainViewModel.saveLunchEvaluation("D", "hate")
+                            homeViewModel.saveLunchEvaluation("D", "hate")
                         }
                         // 자캠 생활관
                         else {
                             if (MyongsikApplication.prefs.getUserArea() == "L") {
                                 DINNER_S = "hate"
                                 getHateChangeDinner()
-                                mainViewModel.saveLunchEvaluation("DS", "hate")
+                                homeViewModel.saveLunchEvaluation("DS", "hate")
                             }
                             if (MyongsikApplication.prefs.getUserArea() == "H") {
 
                                 DINNER_H = "hate"
                                 getHateChangeDinner()
 
-                                mainViewModel.saveLunchEvaluation("DH", "hate")
+                                homeViewModel.saveLunchEvaluation("DH", "hate")
                             }
                         }
                     },

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/HomeFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/HomeFragment.kt
@@ -19,11 +19,12 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
+import com.myongsik.myongsikandroid.MainActivity
 import com.myongsik.myongsikandroid.R
 import com.myongsik.myongsikandroid.data.model.review.RequestReviewData
 import com.myongsik.myongsikandroid.databinding.FragmentHomeBinding
 import com.myongsik.myongsikandroid.ui.adapter.food.MyPagerAdapter
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.food.HomeViewModel
 import com.myongsik.myongsikandroid.util.Constant.DINNER
 import com.myongsik.myongsikandroid.util.Constant.DINNER_H
 import com.myongsik.myongsikandroid.util.Constant.DINNER_S
@@ -50,7 +51,7 @@ class HomeFragment : Fragment() {
     private val binding: FragmentHomeBinding
         get() = _binding!!
 
-    private val mainViewModel by viewModels<MainViewModel>()
+    private val homeViewModel by viewModels<HomeViewModel>()
 
     //back button
     private lateinit var callback: OnBackPressedCallback
@@ -111,7 +112,7 @@ class HomeFragment : Fragment() {
     }
 
     private fun initObserve() {
-        mainViewModel.weekGetFoodArea.observe(viewLifecycleOwner) {
+        homeViewModel.weekGetFoodArea.observe(viewLifecycleOwner) {
             val list = mutableListOf<List<String>>()
 
             settingDate(LocalDate.parse(it.localDateTime.substring(0, 10)))
@@ -127,7 +128,7 @@ class HomeFragment : Fragment() {
             }
 
             with(binding) {
-                viewPager2.adapter = MyPagerAdapter(chunkedList, mainViewModel)
+                viewPager2.adapter = MyPagerAdapter(chunkedList, homeViewModel)
                 viewPager2.orientation = ViewPager2.ORIENTATION_HORIZONTAL
                 setCurrentPage(initDate)
                 indicator.setViewPager(viewPager2)
@@ -137,24 +138,24 @@ class HomeFragment : Fragment() {
 
     private fun initData() {
         if (MyongsikApplication.prefs.getUserCampus() == "S") {
-            mainViewModel.weekGetFoodAreaFun(getAreaName())
+            homeViewModel.weekGetFoodAreaFun(getAreaName())
             binding.homeTimeTv.text = getString(R.string.home_time_tv)
         } else if (MyongsikApplication.prefs.getUserCampus() == "Y") {
             when (MyongsikApplication.prefs.getUserArea()) {
                 "S" -> {
-                    mainViewModel.weekGetFoodAreaFun(getAreaName())
+                    homeViewModel.weekGetFoodAreaFun(getAreaName())
                     binding.homeTimeTv.text = getString(R.string.home_time_staff_tv)
                 }
                 "L" -> {
-                    mainViewModel.weekGetFoodAreaFun(getAreaName())
+                    homeViewModel.weekGetFoodAreaFun(getAreaName())
                     binding.homeTimeTv.text = getString(R.string.home_time_life_tv)
                 }
                 "H" -> {
-                    mainViewModel.weekGetFoodAreaFun(getAreaName())
+                    homeViewModel.weekGetFoodAreaFun(getAreaName())
                     binding.homeTimeTv.text = getString(R.string.home_time_student_tv)
                 }
                 "M" -> {
-                    mainViewModel.weekGetFoodAreaFun(getAreaName())
+                    homeViewModel.weekGetFoodAreaFun(getAreaName())
                     binding.homeTimeTv.text = getString(R.string.home_time_myonog_tv)
                 }
             }
@@ -296,7 +297,7 @@ class HomeFragment : Fragment() {
 
                         writeMenu(review)
 
-                        mainViewModel.postReviewData.observe(viewLifecycleOwner) {
+                        homeViewModel.postReviewData.observe(viewLifecycleOwner) {
                             if (it.success) {
                                 val anotherDialogView = LayoutInflater.from(context).inflate(R.layout.item_review_dialog, null)
                                 val anotherDialog = AlertDialog.Builder(context).setView(anotherDialogView).create().apply {
@@ -322,7 +323,7 @@ class HomeFragment : Fragment() {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
         val formattedDate = currentDate.format(formatter)
         val request = RequestReviewData(review, formattedDate, MyongsikApplication.prefs.getUserID(), getAreaName())
-        mainViewModel.postReview(request)
+        homeViewModel.postReview(request)
     }
 
     //주말
@@ -345,7 +346,7 @@ class HomeFragment : Fragment() {
     //하루가 지났을 때 DataStore 를 초기화함
     private fun defaultDataStore() {
         lifecycleScope.launch {
-            mainViewModel.defaultDataStore()
+            homeViewModel.defaultDataStore()
         }
     }
 
@@ -376,13 +377,13 @@ class HomeFragment : Fragment() {
     //중식 평가 불러오기
     private fun getEvaluation() {
         lifecycleScope.launch { //현재 불러온 값에 따라 값을 저장
-            LUNCH_A_GOOD = mainViewModel.getLunchEvaluation()
-            LUNCH_B_GOOD = mainViewModel.getLunchBEvaluation()
-            DINNER = mainViewModel.getDinnerEvaluation()
-            DINNER_S = mainViewModel.getDinnerSEvaluation()
-            LUNCH_A_GOOD_S = mainViewModel.getLunchSEvaluation()
-            DINNER_H = mainViewModel.getDinnerHEvaluation()
-            LUNCH_A_GOOD_H = mainViewModel.getLunchHEvaluation()
+            LUNCH_A_GOOD = homeViewModel.getLunchEvaluation()
+            LUNCH_B_GOOD = homeViewModel.getLunchBEvaluation()
+            DINNER = homeViewModel.getDinnerEvaluation()
+            DINNER_S = homeViewModel.getDinnerSEvaluation()
+            LUNCH_A_GOOD_S = homeViewModel.getLunchSEvaluation()
+            DINNER_H = homeViewModel.getDinnerHEvaluation()
+            LUNCH_A_GOOD_H = homeViewModel.getLunchHEvaluation()
         }
     }
 }

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/SelectFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/SelectFragment.kt
@@ -10,11 +10,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.myongsik.myongsikandroid.MainActivity
 import com.myongsik.myongsikandroid.R
 import com.myongsik.myongsikandroid.databinding.FragmentSelectBinding
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
 import com.myongsik.myongsikandroid.util.DialogUtils
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import com.myongsik.myongsikandroid.util.NetworkUtils

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/SplashFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/food/SplashFragment.kt
@@ -6,31 +6,32 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.myongsik.myongsikandroid.MainActivity
 import com.myongsik.myongsikandroid.R
 import com.myongsik.myongsikandroid.data.model.user.RequestUserData
 import com.myongsik.myongsikandroid.databinding.FragmentSplashBinding
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.food.SplashViewModel
 import com.myongsik.myongsikandroid.util.DialogUtils
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import com.myongsik.myongsikandroid.util.NetworkUtils
+import dagger.hilt.android.AndroidEntryPoint
 import java.net.ConnectException
 
+@AndroidEntryPoint
 class SplashFragment : Fragment() {
-
     private var _binding: FragmentSplashBinding? = null
     private val binding: FragmentSplashBinding
         get() = _binding!!
 
     private lateinit var mainActivity: MainActivity
-    private val mainViewModel by activityViewModels<MainViewModel>()
+    private val splashViewModel by viewModels<SplashViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -56,9 +57,8 @@ class SplashFragment : Fragment() {
                         requireContext().contentResolver,
                         Settings.Secure.ANDROID_ID
                     )
-                    Log.d("ggplot", "$androidId 신규회원")
                     val requestUser = RequestUserData(androidId)
-                    mainViewModel.postUser(requestUser)
+                    splashViewModel.postUser(requestUser)
                     MyongsikApplication.prefs.setUserId(androidId)
                 } catch (e: ConnectException) {
                     dialogUtils.showConfirmDialog("네트워크 에러가 발생하였습니다.", "다시 접속해주세요.",
@@ -95,7 +95,7 @@ class SplashFragment : Fragment() {
     }
 
     private fun initErrorObserve() {
-        mainViewModel.exceptionLiveData.observe(this) {
+        splashViewModel.exceptionLiveData.observe(this) {
             context?.run {
                 AlertDialog.Builder(this)
                     .setTitle(getString(R.string.error))

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/LoveFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/LoveFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -17,11 +18,14 @@ import com.myongsik.myongsikandroid.ui.adapter.search.OnSearchViewHolderClick
 import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.databinding.FragmentLoveBinding
 import com.myongsik.myongsikandroid.ui.adapter.search.LoveFoodPagingAdapter
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.food.HomeViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.search.LoveViewModel
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 //찜꽁 리스트 화면
+@AndroidEntryPoint
 class LoveFragment : Fragment(), OnSearchViewHolderClick {
 
     private var _binding : FragmentLoveBinding?= null
@@ -30,7 +34,7 @@ class LoveFragment : Fragment(), OnSearchViewHolderClick {
 
     private lateinit var callback: OnBackPressedCallback
 
-    private val mainViewModel by activityViewModels<MainViewModel>()
+    private val loveViewModel by viewModels<LoveViewModel>()
 
     private lateinit var loveFoodAdapter : LoveFoodPagingAdapter
 
@@ -50,13 +54,13 @@ class LoveFragment : Fragment(), OnSearchViewHolderClick {
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED){
-                mainViewModel.loveIsFood.collectLatest {
+                loveViewModel.loveIsFood.collectLatest {
                     if(it.isEmpty()){
                         binding.favoriteEmptyLove.visibility = View.VISIBLE
                     } else {
                         binding.favoriteEmptyLove.visibility = View.INVISIBLE
                     }
-                    mainViewModel.loveFoods.collectLatest { pagedData ->
+                    loveViewModel.loveFoods.collectLatest { pagedData ->
                         loveFoodAdapter.submitData(pagedData)
                     }
                 }
@@ -91,11 +95,11 @@ class LoveFragment : Fragment(), OnSearchViewHolderClick {
     }
 
     override fun addItem(restaurant: Restaurant) {
-        mainViewModel.saveFoods(restaurant)
+
     }
 
     override fun deleteItem(restaurant: Restaurant) {
-        mainViewModel.deleteFoods(restaurant)
+        loveViewModel.deleteFoods(restaurant)
     }
 
     override fun isItem(string: String) {

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/RestaurantFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/RestaurantFragment.kt
@@ -11,13 +11,13 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.snackbar.Snackbar
 import com.myongsik.myongsikandroid.data.model.food.RequestScrap
 import com.myongsik.myongsikandroid.databinding.FragmentRestaurantBinding
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.food.HomeViewModel
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -31,7 +31,7 @@ class RestaurantFragment : Fragment() {
 
     private val args : RestaurantFragmentArgs by navArgs<RestaurantFragmentArgs>()
 
-    private val mainViewModel by activityViewModels<MainViewModel>()
+    private val homeViewModel by viewModels<HomeViewModel>()
 
     private lateinit var callback: OnBackPressedCallback
 
@@ -91,9 +91,9 @@ class RestaurantFragment : Fragment() {
             loadUrl(restaurant.place_url)
         }
 
-        mainViewModel.loveIs(restaurant)
+        homeViewModel.loveIs(restaurant)
 
-        mainViewModel.loveIs.observe(viewLifecycleOwner){
+        homeViewModel.loveIs.observe(viewLifecycleOwner){
             if(it == null){
                 binding.fabFavorite.visibility = View.VISIBLE
                 binding.fabFavoriteLove.visibility = View.INVISIBLE
@@ -114,8 +114,8 @@ class RestaurantFragment : Fragment() {
         binding.fabFavorite.setOnClickListener {
             binding.fabFavorite.visibility = View.INVISIBLE
             binding.fabFavoriteLove.visibility = View.VISIBLE
-            mainViewModel.saveFoods(restaurant)
-            mainViewModel.scarpRestaurant(requestScrap = RequestScrap(
+            homeViewModel.saveFoods(restaurant)
+            homeViewModel.scarpRestaurant(requestScrap = RequestScrap(
                 address = restaurant.road_address_name,
                 campus = campus!!,
                 category = restaurant.category_group_name,
@@ -132,7 +132,7 @@ class RestaurantFragment : Fragment() {
         binding.fabFavoriteLove.setOnClickListener {
             binding.fabFavorite.visibility = View.VISIBLE
             binding.fabFavoriteLove.visibility = View.INVISIBLE
-            mainViewModel.deleteFoods(restaurant)
+            homeViewModel.deleteFoods(restaurant)
             Snackbar.make(view, "찜 목록에서 삭제되었습니다.", Snackbar.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/RestaurantFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/RestaurantFragment.kt
@@ -18,6 +18,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.myongsik.myongsikandroid.data.model.food.RequestScrap
 import com.myongsik.myongsikandroid.databinding.FragmentRestaurantBinding
 import com.myongsik.myongsikandroid.ui.viewmodel.food.HomeViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.search.LoveViewModel
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -31,7 +32,7 @@ class RestaurantFragment : Fragment() {
 
     private val args : RestaurantFragmentArgs by navArgs<RestaurantFragmentArgs>()
 
-    private val homeViewModel by viewModels<HomeViewModel>()
+    private val loveViewModel by viewModels<LoveViewModel>()
 
     private lateinit var callback: OnBackPressedCallback
 
@@ -91,9 +92,9 @@ class RestaurantFragment : Fragment() {
             loadUrl(restaurant.place_url)
         }
 
-        homeViewModel.loveIs(restaurant)
+        loveViewModel.loveIs(restaurant)
 
-        homeViewModel.loveIs.observe(viewLifecycleOwner){
+        loveViewModel.loveIs.observe(viewLifecycleOwner){
             if(it == null){
                 binding.fabFavorite.visibility = View.VISIBLE
                 binding.fabFavoriteLove.visibility = View.INVISIBLE
@@ -114,8 +115,8 @@ class RestaurantFragment : Fragment() {
         binding.fabFavorite.setOnClickListener {
             binding.fabFavorite.visibility = View.INVISIBLE
             binding.fabFavoriteLove.visibility = View.VISIBLE
-            homeViewModel.saveFoods(restaurant)
-            homeViewModel.scarpRestaurant(requestScrap = RequestScrap(
+            loveViewModel.saveFoods(restaurant)
+            loveViewModel.scarpRestaurant(requestScrap = RequestScrap(
                 address = restaurant.road_address_name,
                 campus = campus!!,
                 category = restaurant.category_group_name,
@@ -132,7 +133,7 @@ class RestaurantFragment : Fragment() {
         binding.fabFavoriteLove.setOnClickListener {
             binding.fabFavorite.visibility = View.VISIBLE
             binding.fabFavoriteLove.visibility = View.INVISIBLE
-            homeViewModel.deleteFoods(restaurant)
+            loveViewModel.deleteFoods(restaurant)
             Snackbar.make(view, "찜 목록에서 삭제되었습니다.", Snackbar.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/SearchFragment.kt
@@ -29,8 +29,8 @@ import com.myongsik.myongsikandroid.ui.adapter.food.RankRestaurantAdapter
 import com.myongsik.myongsikandroid.ui.adapter.search.OnSearchViewHolderClick
 import com.myongsik.myongsikandroid.ui.adapter.search.SearchFoodPagingAdapter
 import com.myongsik.myongsikandroid.ui.adapter.state.SearchFoodLoadStateAdapter
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
-import com.myongsik.myongsikandroid.ui.viewmodel.SearchViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.food.HomeViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.search.SearchViewModel
 import com.myongsik.myongsikandroid.util.CommonUtil
 import com.myongsik.myongsikandroid.util.Constant.SEARCH_FOODS_TIME_DELAY
 import com.myongsik.myongsikandroid.util.DataStoreKey
@@ -50,7 +50,7 @@ import kotlin.random.Random
 
     //검색 뷰모델, 현재 의존성 주입 안함
     private val searchViewModel by viewModels<SearchViewModel>()
-    private val mainViewModel by viewModels<MainViewModel>()
+    private val homeViewModel by viewModels<HomeViewModel>()
 
     //검색 어댑터 -> PagingAdapter
     private lateinit var searchFoodAdapter: SearchFoodPagingAdapter
@@ -126,7 +126,7 @@ import kotlin.random.Random
     }
 
     private fun initRankObserve() {
-        mainViewModel.rankRestaurantResponse.observe(viewLifecycleOwner) {
+        homeViewModel.rankRestaurantResponse.observe(viewLifecycleOwner) {
             binding.refreshLayout.isRefreshing = false
             val response = it.data.content
             rankRestaurantAdapter.submitList(response)
@@ -248,11 +248,11 @@ import kotlin.random.Random
     }
 
     override fun addItem(restaurant: Restaurant) {
-        mainViewModel.saveFoods(restaurant)
+
     }
 
     override fun deleteItem(restaurant: Restaurant) {
-        mainViewModel.deleteFoods(restaurant)
+
     }
 
     override fun isItem(string: String) {
@@ -305,17 +305,17 @@ import kotlin.random.Random
 
     override fun onSelectSortMenu(sort: String) {
         currentMenu = sort
-        mainViewModel.saveSortType(DataStoreKey.SORT_TYPE, sort)
+        homeViewModel.saveSortType(DataStoreKey.SORT_TYPE, sort)
         val randomPosition = Random.nextInt(foodList.size)
         when (sort) {
             getString(R.string.rank_sort_menu_popularity) -> {
-                mainViewModel.getRankRestaurant()
+                homeViewModel.getRankRestaurant()
             }
             getString(R.string.rank_sort_menu_suggestion) -> {
                 searchViewModel.searchRecommendFood(foodList[randomPosition])
             }
             getString(R.string.rank_sort_menu_distance) -> {
-                mainViewModel.getDistanceRestaurant()
+                homeViewModel.getDistanceRestaurant()
             }
             else -> {
                 return
@@ -326,22 +326,22 @@ import kotlin.random.Random
     private fun getFoodData() {
         lifecycleScope.launch {
             val randomPosition = Random.nextInt(foodList.size)
-            when (mainViewModel.getCurrentSortType()) {
+            when (homeViewModel.getCurrentSortType()) {
                 getString(R.string.rank_sort_menu_suggestion) -> {
                     searchViewModel.searchRecommendFood(foodList[randomPosition])
                 }
                 getString(R.string.rank_sort_menu_distance) -> {
-                    mainViewModel.getDistanceRestaurant()
+                    homeViewModel.getDistanceRestaurant()
                 }
                 else -> {
-                    mainViewModel.getRankRestaurant()
+                    homeViewModel.getRankRestaurant()
                 }
             }
         }
     }
 
     private suspend fun getSorTypePosition(): Int {
-        val sortTypePosition = when (mainViewModel.getCurrentSortType()) {
+        val sortTypePosition = when (homeViewModel.getCurrentSortType()) {
             getString(R.string.rank_sort_menu_suggestion) -> {
                 1
             }

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/TagFragment.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/view/search/TagFragment.kt
@@ -5,17 +5,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.myongsik.myongsikandroid.ui.adapter.search.OnSearchViewHolderClick
 import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.databinding.FragmentTagBinding
+import com.myongsik.myongsikandroid.ui.adapter.search.OnSearchViewHolderClick
 import com.myongsik.myongsikandroid.ui.adapter.search.SearchFoodPagingAdapter
-import com.myongsik.myongsikandroid.ui.viewmodel.MainViewModel
-import com.myongsik.myongsikandroid.ui.viewmodel.SearchViewModel
+import com.myongsik.myongsikandroid.ui.viewmodel.search.SearchViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -31,8 +30,7 @@ class TagFragment : Fragment(), OnSearchViewHolderClick {
     private val args: TagFragmentArgs by navArgs()
 
     //검색 뷰모델
-    private val searchViewModel by activityViewModels<SearchViewModel>()
-    private val mainViewModel by activityViewModels<MainViewModel>()
+    private val searchViewModel by viewModels<SearchViewModel>()
 
     private lateinit var tagFoodAdapter: SearchFoodPagingAdapter
 
@@ -79,20 +77,20 @@ class TagFragment : Fragment(), OnSearchViewHolderClick {
         super.onDestroyView()
     }
 
+    override fun clickDirectButton(restaurant: Restaurant) {
+        val action = TagFragmentDirections.actionFragmentTagToFragmentRestaurant(restaurant)
+        findNavController().navigate(action)
+    }
+
     override fun addItem(restaurant: Restaurant) {
-        mainViewModel.saveFoods(restaurant)
+
     }
 
     override fun deleteItem(restaurant: Restaurant) {
-        mainViewModel.deleteFoods(restaurant)
+
     }
 
     override fun isItem(string: String) {
 
-    }
-
-    override fun clickDirectButton(restaurant: Restaurant) {
-        val action = TagFragmentDirections.actionFragmentTagToFragmentRestaurant(restaurant)
-        findNavController().navigate(action)
     }
 }

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/HomeViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/HomeViewModel.kt
@@ -103,36 +103,6 @@ class HomeViewModel @Inject constructor(
         foodRepository.getCurrentSortType().first()
     }
 
-    //Room
-    fun saveFoods(restaurant: Restaurant) = launch {
-        foodRepository.insertFoods(restaurant)
-    }
-
-    fun deleteFoods(restaurant: Restaurant) = launch {
-        foodRepository.deleteFoods(restaurant)
-    }
-
-    private val _loveIs = MutableLiveData<Restaurant>()
-    val loveIs: LiveData<Restaurant>
-        get() = _loveIs
-
-    fun loveIs(restaurant: Restaurant) = launch {
-        val restaurantLove = foodRepository.loveIs(restaurant.id)
-        _loveIs.postValue(restaurantLove)
-    }
-
-    private val _scrapRestaurant = MutableLiveData<ResponseScrap>()
-    val scrapRestaurant: LiveData<ResponseScrap>
-        get() = _scrapRestaurant
-
-    fun scarpRestaurant(requestScrap: RequestScrap) = launch {
-        val response = foodRepository.postScrapRestaurant(requestScrap)
-
-        if (response.code() == 200) {
-            _scrapRestaurant.postValue(response.body())
-        }
-    }
-
     private val _rankRestaurantResponse = MutableLiveData<RankRestaurantResponse>()
     val rankRestaurantResponse: LiveData<RankRestaurantResponse>
         get() = _rankRestaurantResponse

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/HomeViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/HomeViewModel.kt
@@ -3,23 +3,16 @@ package com.myongsik.myongsikandroid.ui.viewmodel.food
 import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
 import com.myongsik.myongsikandroid.data.model.food.*
-import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.data.model.review.RequestReviewData
 import com.myongsik.myongsikandroid.data.model.review.ResponseReviewData
 import com.myongsik.myongsikandroid.data.repository.food.FoodRepository
-import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
+import com.myongsik.myongsikandroid.BaseViewModel
 import com.myongsik.myongsikandroid.util.Constant
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/HomeViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/HomeViewModel.kt
@@ -1,4 +1,4 @@
-package com.myongsik.myongsikandroid.ui.viewmodel
+package com.myongsik.myongsikandroid.ui.viewmodel.food
 
 import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.LiveData
@@ -10,9 +10,8 @@ import com.myongsik.myongsikandroid.data.model.food.*
 import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.data.model.review.RequestReviewData
 import com.myongsik.myongsikandroid.data.model.review.ResponseReviewData
-import com.myongsik.myongsikandroid.data.model.user.RequestUserData
-import com.myongsik.myongsikandroid.data.model.user.ResponseUserData
 import com.myongsik.myongsikandroid.data.repository.food.FoodRepository
+import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
 import com.myongsik.myongsikandroid.util.Constant
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,7 +24,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor(
+class HomeViewModel @Inject constructor(
     private val foodRepository: FoodRepository
 ) : BaseViewModel() {
 
@@ -36,10 +35,6 @@ class MainViewModel @Inject constructor(
     private val _postReviewData = MutableLiveData<ResponseReviewData>()
     val postReviewData: LiveData<ResponseReviewData>
         get() = _postReviewData
-
-    private val _postUserData = MutableLiveData<ResponseUserData>()
-    val postUserData: LiveData<ResponseUserData>
-        get() = _postUserData
 
     private val _postMealData = MutableLiveData<ResponseMealData>()
     val postMealData: LiveData<ResponseMealData>
@@ -58,14 +53,6 @@ class MainViewModel @Inject constructor(
 
         if (response.code() == 200) {
             _postReviewData.postValue(response.body())
-        }
-    }
-
-    fun postUser(requestUserData: RequestUserData) = launch {
-        val response = foodRepository.postUser(requestUserData)
-
-        if (response.code() == 200) {
-            _postUserData.postValue(response.body())
         }
     }
 
@@ -133,23 +120,6 @@ class MainViewModel @Inject constructor(
         val restaurantLove = foodRepository.loveIs(restaurant.id)
         _loveIs.postValue(restaurantLove)
     }
-
-    val loveFoods: StateFlow<PagingData<Restaurant>> =
-        foodRepository.getFoods()
-            .cachedIn(viewModelScope)
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), PagingData.empty())
-
-    private val _isUpdate = MutableLiveData<Boolean>(false)
-    val isUpdate: LiveData<Boolean>
-        get() = _isUpdate
-
-    fun loveUpdate(string: String) = launch {
-        val restaurantLove = foodRepository.updateLove(string)
-        _isUpdate.postValue(restaurantLove)
-    }
-
-    val loveIsFood: StateFlow<List<Restaurant>> = foodRepository.getLoveIsFood()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf())
 
     private val _scrapRestaurant = MutableLiveData<ResponseScrap>()
     val scrapRestaurant: LiveData<ResponseScrap>

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/SplashViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/SplashViewModel.kt
@@ -1,0 +1,28 @@
+package com.myongsik.myongsikandroid.ui.viewmodel.food
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.myongsik.myongsikandroid.data.model.user.RequestUserData
+import com.myongsik.myongsikandroid.data.model.user.ResponseUserData
+import com.myongsik.myongsikandroid.data.repository.food.FoodRepository
+import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val foodRepository: FoodRepository
+) : BaseViewModel() {
+
+    private val _postUserData = MutableLiveData<ResponseUserData>()
+    val postUserData: LiveData<ResponseUserData>
+        get() = _postUserData
+
+    fun postUser(requestUserData: RequestUserData) = launch {
+        val response = foodRepository.postUser(requestUserData)
+
+        if (response.code() == 200) {
+            _postUserData.postValue(response.body())
+        }
+    }
+}

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/SplashViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/food/SplashViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.myongsik.myongsikandroid.data.model.user.RequestUserData
 import com.myongsik.myongsikandroid.data.model.user.ResponseUserData
 import com.myongsik.myongsikandroid.data.repository.food.FoodRepository
-import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
+import com.myongsik.myongsikandroid.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/LoveViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/LoveViewModel.kt
@@ -9,7 +9,7 @@ import com.myongsik.myongsikandroid.data.model.food.RequestScrap
 import com.myongsik.myongsikandroid.data.model.food.ResponseScrap
 import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.data.repository.food.FoodRepository
-import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
+import com.myongsik.myongsikandroid.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/LoveViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/LoveViewModel.kt
@@ -1,8 +1,12 @@
 package com.myongsik.myongsikandroid.ui.viewmodel.search
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.myongsik.myongsikandroid.data.model.food.RequestScrap
+import com.myongsik.myongsikandroid.data.model.food.ResponseScrap
 import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.data.repository.food.FoodRepository
 import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
@@ -17,8 +21,23 @@ class LoveViewModel @Inject constructor(
     private val foodRepository: FoodRepository
 ) : BaseViewModel() {
 
+    //Room
+    fun saveFoods(restaurant: Restaurant) = launch {
+        foodRepository.insertFoods(restaurant)
+    }
+
     fun deleteFoods(restaurant: Restaurant) = launch {
         foodRepository.deleteFoods(restaurant)
+    }
+
+    //Api
+    private val _loveIs = MutableLiveData<Restaurant>()
+    val loveIs: LiveData<Restaurant>
+        get() = _loveIs
+
+    fun loveIs(restaurant: Restaurant) = launch {
+        val restaurantLove = foodRepository.loveIs(restaurant.id)
+        _loveIs.postValue(restaurantLove)
     }
 
     val loveIsFood: StateFlow<List<Restaurant>> = foodRepository.getLoveIsFood()
@@ -28,4 +47,16 @@ class LoveViewModel @Inject constructor(
         foodRepository.getFoods()
             .cachedIn(viewModelScope)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), PagingData.empty())
+
+    private val _scrapRestaurant = MutableLiveData<ResponseScrap>()
+    val scrapRestaurant: LiveData<ResponseScrap>
+        get() = _scrapRestaurant
+
+    fun scarpRestaurant(requestScrap: RequestScrap) = launch {
+        val response = foodRepository.postScrapRestaurant(requestScrap)
+
+        if (response.code() == 200) {
+            _scrapRestaurant.postValue(response.body())
+        }
+    }
 }

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/LoveViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/LoveViewModel.kt
@@ -1,0 +1,31 @@
+package com.myongsik.myongsikandroid.ui.viewmodel.search
+
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
+import com.myongsik.myongsikandroid.data.repository.food.FoodRepository
+import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class LoveViewModel @Inject constructor(
+    private val foodRepository: FoodRepository
+) : BaseViewModel() {
+
+    fun deleteFoods(restaurant: Restaurant) = launch {
+        foodRepository.deleteFoods(restaurant)
+    }
+
+    val loveIsFood: StateFlow<List<Restaurant>> = foodRepository.getLoveIsFood()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf())
+
+    val loveFoods: StateFlow<PagingData<Restaurant>> =
+        foodRepository.getFoods()
+            .cachedIn(viewModelScope)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), PagingData.empty())
+}

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/SearchViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/SearchViewModel.kt
@@ -1,4 +1,4 @@
-package com.myongsik.myongsikandroid.ui.viewmodel
+package com.myongsik.myongsikandroid.ui.viewmodel.search
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -8,9 +8,9 @@ import androidx.paging.cachedIn
 import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.data.model.kakao.SearchResponse
 import com.myongsik.myongsikandroid.data.repository.search.SearchFoodRepository
+import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/SearchViewModel.kt
+++ b/app/src/main/java/com/myongsik/myongsikandroid/ui/viewmodel/search/SearchViewModel.kt
@@ -8,7 +8,7 @@ import androidx.paging.cachedIn
 import com.myongsik.myongsikandroid.data.model.kakao.Restaurant
 import com.myongsik.myongsikandroid.data.model.kakao.SearchResponse
 import com.myongsik.myongsikandroid.data.repository.search.SearchFoodRepository
-import com.myongsik.myongsikandroid.ui.viewmodel.BaseViewModel
+import com.myongsik.myongsikandroid.BaseViewModel
 import com.myongsik.myongsikandroid.util.MyongsikApplication
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.view.food.MainActivity">
+    tools:context=".MainActivity">
 
     <FrameLayout
         android:id="@+id/frame_layout"


### PR DESCRIPTION
## 변경사항
- #87 
- ViewModel 관심사 분리
- 기존 MainViewModel, SearchViewModel 이 외에 SplashViewModel, LoveViewModel 추가
- MainViewModel을 HomeViewModel로 네이밍 변경

## 고민사항
- SearchFragment 에서 식당랭킹 api, 카카오 Search api 를 같이 불러오기 때문에 HomeViewModel, SearchViewModel 두 개를 참조하고 있음
- SearchFragment이니 만큼 SearchViewModel만 바라보게 하고 싶은데, DataStore, 거리순, 랭킹순 등 다양한 것을 HomeViewModel을 통해 불러오기 때문에 Repository 까지 변경하게 될 것 같음. 
- 따라서 이 부분은 의논 후에 변경할게요! 모두 이 부분에 대해서 의견 주시면 감사하겠습니다